### PR TITLE
Changed mongodb driver to latest version (1.3.19)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/diversario/connect-mongostore/issues"
   },
   "dependencies": {
-    "mongodb": "~1.3.0",
+    "mongodb": "~1.3.19",
     "lodash": "~2.2.0"
   },
   "directories": {


### PR DESCRIPTION
I was having some issues with replica sets in MongoDB which have been corrected in the versions released after 1.3.0. Since this module is using 1.3.0, I have pushed the dependency to 1.3.19. I've tested and confirmed that this module is working correctly with the latest release of the driver.
