### PR TITLE
Add support for Express 4.x

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,0 +1,6 @@
+0.1.0 / 2014-04-14 
+==================
+
+ * Add support for Express 4.x by passing in reference to `session` instead of reference to `express`
+ * Updated Readme to reflect the updates and support for Express
+ * Add History.md to track changes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # connect-mongostore
 
-  MongoDB session store for Connect
+  MongoDB session store for Connect/Express
 
   [![Build Status](https://secure.travis-ci.org/diversario/connect-mongostore.png?branch=master)](http://travis-ci.org/diversario/connect-mongostore)
   [![Coverage Status](https://coveralls.io/repos/diversario/connect-mongostore/badge.png?branch=master)](https://coveralls.io/r/diversario/connect-mongostore?branch=master)
@@ -13,7 +13,7 @@
 
 ## Installation
 
-connect-mongostore supports only connect `>= 1.0.3`.
+connect-mongostore supports connect `>= 1.0.3`, express `3.x` and express `4.x` with express-session.
 
 via npm:
 
@@ -70,12 +70,25 @@ starting your app.
 
 ## Example
 
-With express:
+With express 3.x:
 
     var express = require('express');
     var MongoStore = require('connect-mongostore')(express);
-
+    var app = express();
+    
     app.use(express.session({
+        secret: 'my secret',
+        store: new MongoStore({'db': 'sessions'})
+      }));
+
+With express 4.x:
+
+    var express = require('express');
+    var session = require('express-session');
+    var MongoStore = require('connect-mongostore')(session);
+    var app = express();
+
+    app.use(session({
         secret: 'my secret',
         store: new MongoStore({'db': 'sessions'})
       }));

--- a/lib/connect-mongostore.js
+++ b/lib/connect-mongostore.js
@@ -350,5 +350,5 @@ function dbFromMongooseConnection(mongooseConnection, opts) {
 
 
 module.exports = function (connect) {
-  return getStore(connect.session.Store)
+  return getStore(connect.Store? connect.Store : connect.session.Store)
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-mongostore",
-  "version": "0.0.12",
+  "version": "0.1.0",
   "description": "MongoDB session store for Connect",
   "keywords": [
     "connect",
@@ -18,7 +18,7 @@
     "url": "https://github.com/diversario/connect-mongostore/issues"
   },
   "dependencies": {
-    "mongodb": "~1.3.19",
+    "mongodb": "~1.4.0",
     "lodash": "~2.2.0"
   },
   "directories": {


### PR DESCRIPTION
Added support for Express 4.x by allowing direct reference to `session` to be passed into connect-mongostore since session is no longer bundled with Express. It is still backward compatible with Connect and Express 3.x. With this change, I bumped to version to 0.1.0 since this is a backwards compatible API change. I've also added a `History.md` file to track changes going forward.

If you have any questions on the changes, please free to let me know.
