### PR TITLE
Added support for post-db-connect callback.

### DIFF
--- a/lib/connect-mongostore.js
+++ b/lib/connect-mongostore.js
@@ -28,7 +28,7 @@ function getStore(Store) {
    *
    * @param {Object} options
    */
-  function MongoStore (options) {
+  function MongoStore (options, callback) {
     Store.call(this, this.options)
 
     if (typeof options == 'string') {
@@ -44,6 +44,8 @@ function getStore(Store) {
 
     this.collectionName = this.options.collection || defaultOptions.collection
     this.db = setupDb(this.options)
+
+    callback && this.getDatabase(callback);
   }
 
 


### PR DESCRIPTION
If you put app.listen() for express apps inside the callback, it fixes many session TTL timeout issues that occur for many people.

Similar issues have been raised in connect-mongo, but have only been resolved through callbacks such as this. Since this library supports replica-sets like I'm using, I chose it, but suffered from session TTL issues before implementing this callback. Figured I'd share. :)

Thoughts? I'm super curious why this wasn't added in the beginning!
