### PR TITLE
Updating the url parse function to support replica sets using the Mongodb parsing function and some mapping logic

### DIFF
--- a/lib/connect-mongostore.js
+++ b/lib/connect-mongostore.js
@@ -274,6 +274,7 @@ function parseUrl(path) {
       options.db.name = mongoOptions.dbName;
       options.db.servers = mongoOptions.servers;
       options.db.replicaSetOptions = _.merge({'w': 1}, mongoOptions.db_options, mongoOptions.rs_options);
+      options.db.replicaSetOptions.autoReconnect =  options.db.replicaSetOptions.autoReconnect || options.autoReconnect;
   }
   else {
     options.db = mongoOptions.dbName;
@@ -305,37 +306,31 @@ function parseUrl(path) {
  */
 function setupDb(opts) {
   if (opts.mongooseConnection) {
-    var _opts = dbFromMongooseConnection(opts.mongooseConnection);
-    opts.db = _opts.db;
-    opts.host = _opts.host;
-    opts.port = _opts.port;
-    opts.username = _opts.username;
-    opts.password = _opts.password;
+    var _opts = dbFromMongooseConnection(opts.mongooseConnection)
+    opts.db = _opts.db
+    opts.host = _opts.host
+    opts.port = _opts.port
+    opts.username = _opts.username
+    opts.password = _opts.password
   }
 
-  if (!opts.db) {
-    throw new Error('Required MongoStore option `db` missing');
-  }
-
-  if (typeof opts.db == 'object' && opts.db.databaseName) {
-    return opts.db; // Assume it's an instantiated DB Object
-  }
+  if (!opts.db) throw new Error('Required MongoStore option `db` missing')
+  if (typeof opts.db == 'object' && opts.db.databaseName) return opts.db // Assume it's an instantiated DB Object
 
   if (Array.isArray(opts.db.servers)) {
-    var serverArray = [];
+    var serverArray = []
+
     opts.db.servers.forEach(function (server) {
-      var serverOptions = server.options || {};
-      serverOptions.ssl = serverOptions.ssl || opts.ssl || defaultOptions.ssl;
-      var newServer = new mongo.Server(server.host, server.port, serverOptions);
-      serverArray.push(newServer);
+      var serverOptions = server.options || {}
+      serverOptions.ssl = serverOptions.ssl || opts.ssl || defaultOptions.ssl
+      var newServer = new mongo.Server(server.host, server.port, serverOptions)
+      serverArray.push(newServer)
     })
 
-    return new mongo.Db(opts.db.name, new mongo.ReplSetServers(serverArray), opts.db.replicaSetOptions || {'w': 1});
+    return new mongo.Db(opts.db.name, new mongo.ReplSetServers(serverArray), opts.db.replicaSetOptions || {'w': 1})
   }
 
-  if (typeof opts.db != 'string') {
-    throw new Error('`db` option must be a string, array or a database instance.')
-  }
+  if (typeof opts.db != 'string') throw new Error('`db` option must be a string, array or a database instance.')
 
   return new mongo.Db(
     opts.db, new mongo.Server(
@@ -345,7 +340,7 @@ function setupDb(opts) {
         auto_reconnect: opts.autoReconnect || defaultOptions.autoReconnect,
         ssl: opts.ssl || defaultOptions.ssl
       }),
-    { w: opts.w || defaultOptions.w });
+    { w: opts.w || defaultOptions.w })
 }
 
 

--- a/lib/connect-mongostore.js
+++ b/lib/connect-mongostore.js
@@ -1,9 +1,9 @@
-"use strict"
+'use strict'
 
-var mongo = require('mongodb'),
-    url = require('url'),
-    util = require('util'),
-    _ = require('lodash');
+var mongo = require('mongodb')
+  , url = require('url')
+  , util = require('util')
+  , _ = require('lodash')
 
 
 /**
@@ -18,7 +18,7 @@ var defaultOptions = {
   'autoReconnect': false,
   'ssl': false,
   'w': 1
-};
+}
 
 
 
@@ -29,28 +29,23 @@ function getStore(Store) {
    * @param {Object} options
    */
   function MongoStore (options, callback) {
-    var self = this;
-
     Store.call(this, this.options)
 
-    if (typeof options === 'string') {
-      this.options = parseUrl(options);
-    }
-    else {
-      this.options = _.clone(options || {});
-      this.options.expireAfter = this.options.expireAfter || defaultOptions.expireAfter;
+    if (typeof options == 'string') {
+      this.options = parseUrl(options)
+    } else {
+      this.options = _.clone(options || {})
+      this.options.expireAfter = this.options.expireAfter || defaultOptions.expireAfter
     }
 
     if (!this.options.hasOwnProperty('stringify')) {
-      this.options.stringify = defaultOptions.stringify;
+      this.options.stringify = defaultOptions.stringify
     }
 
-    this.collectionName = this.options.collection || defaultOptions.collection;
+    this.collectionName = this.options.collection || defaultOptions.collection
+    this.db = setupDb(this.options)
 
-    mongo.MongoClient.connect(options, function(err, database) {
-        self.db = database;
-        callback && self.getCollection(callback);
-    });
+    callback && this.getDatabase(callback);
   }
 
 
@@ -58,24 +53,43 @@ function getStore(Store) {
   /**
    * Inherit from `Store`.
    */
-  util.inherits(MongoStore, Store);
+  util.inherits(MongoStore, Store)
 
 
 
   MongoStore.prototype.serialize = function (obj) {
     if (this.options.stringify) {
-      return JSON.stringify(obj);
+      return JSON.stringify(obj)
     }
-    return obj;
+    return obj
   }
 
 
   MongoStore.prototype.deserialize = function (str) {
     if (this.options.stringify) {
-      return JSON.parse(str);
+      return JSON.parse(str)
     }
-    return str;
+    return str
   }
+
+
+  MongoStore.prototype.getDatabase = function (cb) {
+    var self = this
+
+    self.db.open(function (err, db) {
+      if (err) throw new Error('Error connecting to database:\n' + err.message + '\n' + err.stack + '\n')
+
+      if (self.options.username && self.options.password) {
+        db.authenticate(self.options.username, self.options.password, {authSource: self.options.authSource || null}, function () {
+          self.getCollection(cb)
+        })
+      } else {
+        self.getCollection(cb)
+      }
+    })
+  }
+
+
 
   /**
    * Returns a MongoDB collection.
@@ -83,25 +97,23 @@ function getStore(Store) {
    * @param cb
    */
   MongoStore.prototype.getCollection = function (cb) {
-    var self = this;
+    var self = this
 
     if (self.collection) {
-      cb && cb(self.collection);
-      return;
+      cb && cb(self.collection)
+      return
     }
 
-    self.db.collection(self.collectionName, function (err, collection) {
-      if (err) {
-        throw new Error('Error getting collection: ' + self.collectionName + ' <' + err + '>')
-      }
+    if (!self.db.openCalled) return self.getDatabase(cb)
 
-      self.collection = collection;
+    self.db.collection(self.collectionName, function (err, collection) {
+      if (err) throw new Error('Error getting collection: ' + self.collectionName + ' <' + err + '>')
+
+      self.collection = collection
 
       self.collection.ensureIndex({'expires': 1}, {'expireAfterSeconds': 0}, function (err, result) {
-        if (err) {
-            throw new Error('Error setting TTL index on collection : ' + self.collectionName + ' <' + err + '>')
-        }
-        cb && cb(self.collection);
+        if (err) throw new Error('Error setting TTL index on collection : ' + self.collectionName + ' <' + err + '>')
+        cb && cb(self.collection)
       })
     })
   }
@@ -237,43 +249,71 @@ function getFutureDate(offset) {
  * @returns {Object}
  */
 function parseUrl(path) {
-  var parsed = {}
+  var urlParser = require('mongodb/lib/mongodb/connection/url_parser');
+  var mongoOptions = urlParser.parse(path);
 
-  var dbUri = url.parse(path)
+  var options = {}
 
-  if (dbUri.port) {
-    parsed.port = parseInt(dbUri.port)
+  // Get auth
+  if (mongoOptions.auth != undefined) {
+    options.username = mongoOptions.auth.username;
+
+    if (mongoOptions.auth.password ) {
+        options.password = mongoOptions.auth.password;
+    }
   }
 
+  options = _.merge({'w': 1}, mongoOptions.db_options);
+
+  options.db = mongoOptions.dbName;
+
+  options.db.replicaSetOptions = _.merge({'w': 1}, mongoOptions.db_options, mongoOptions.rs_options);
+
+  if (mongoOptions.servers.length > 1) {
+      options.db.servers = mongoOptions.servers;
+  }
+  else {
+    options.host = mongoOptions.servers[0].host;
+    options.port = parseInt(mongoOptions.servers[0].port);
+  }
+
+  // Mongdb does not support a collection name on the second segment. So we continue this workaround.
+  var dbUri = url.parse(path);
   if (dbUri.pathname != undefined) {
     var pathname = dbUri.pathname.split('/')
 
-    if (pathname.length >= 2 && pathname[1]) {
-      parsed.db = pathname[1]
-    }
-
     if (pathname.length >= 3 && pathname[2]) {
-      parsed.collection = pathname[2]
+      options.collection = pathname[2]
     }
   }
 
-  if (dbUri.hostname != undefined) {
-    parsed.host = dbUri.hostname
-  }
 
-  if (dbUri.auth != undefined) {
-    var auth = dbUri.auth.split(':')
+/*
+  Note: We have mongoOptions.mongos_options available as well...
 
-    if (auth.length >= 1) {
-      parsed.username = auth[0]
-    }
+  object.dbName
+  object.server_options = serverOptions;
+  object.db_options = dbOptions;
+  object.rs_options = replSetServersOptions;
+  object.mongos_options = {};
+  object.servers
 
-    if (auth.length >= 2) {
-      parsed.password = auth[1]
-    }
-  }
+  if (Array.isArray(opts.db.servers)) {
+    var serverArray = []
 
-  return parsed
+    opts.db.servers.forEach(function (server) {
+      var serverOptions = server.options || {}
+      serverOptions.ssl = serverOptions.ssl || opts.ssl || defaultOptions.ssl
+      var newServer = new mongo.Server(server.host, server.port, serverOptions)
+      serverArray.push(newServer)
+    })
+
+    return new mongo.Db(opts.db.name, new mongo.ReplSetServers(serverArray), opts.db.replicaSetOptions || {'w': 1})
+
+
+*/
+
+  return options;
 }
 
 
@@ -283,8 +323,7 @@ function parseUrl(path) {
  *
  * @param opts
  * @returns {*}
-    MongoDb*/
-
+ */
 function setupDb(opts) {
   if (opts.mongooseConnection) {
     var _opts = dbFromMongooseConnection(opts.mongooseConnection)
@@ -296,7 +335,9 @@ function setupDb(opts) {
   }
 
   if (!opts.db) throw new Error('Required MongoStore option `db` missing')
-  if (typeof opts.db == 'object' && opts.db.databaseName) return opts.db // Assume it's an instantiated DB Object
+  if (typeof opts.db == 'object' && opts.db.databaseName) {
+    return opts.db; // Assume it's an instantiated DB Object
+  }
 
   if (Array.isArray(opts.db.servers)) {
     var serverArray = []
@@ -311,7 +352,9 @@ function setupDb(opts) {
     return new mongo.Db(opts.db.name, new mongo.ReplSetServers(serverArray), opts.db.replicaSetOptions || {'w': 1})
   }
 
-  if (typeof opts.db != 'string') throw new Error('`db` option must be a string, array or a database instance.')
+  if (typeof opts.db != 'string') {
+    throw new Error('`db` option must be a string, array or a database instance.')
+  }
 
   return new mongo.Db(
     opts.db, new mongo.Server(

--- a/lib/connect-mongostore.js
+++ b/lib/connect-mongostore.js
@@ -264,17 +264,22 @@ function parseUrl(path) {
   }
 
   options = _.merge({'w': 1}, mongoOptions.db_options);
-
-  options.db = mongoOptions.dbName;
-
-  options.db.replicaSetOptions = _.merge({'w': 1}, mongoOptions.db_options, mongoOptions.rs_options);
+  if (mongoOptions['server_options'] && mongoOptions['server_options']['auto_reconnect']) {
+      options.autoReconnect = mongoOptions['server_options']['auto_reconnect'];
+  }
 
   if (mongoOptions.servers.length > 1) {
+      var srvr = mongoOptions.servers[0];
+      options.db = {};
+      options.db.name = mongoOptions.dbName;
       options.db.servers = mongoOptions.servers;
+      options.db.replicaSetOptions = _.merge({'w': 1}, mongoOptions.db_options, mongoOptions.rs_options);
   }
   else {
-    options.host = mongoOptions.servers[0].host;
-    options.port = parseInt(mongoOptions.servers[0].port);
+    options.db = mongoOptions.dbName;
+    var srvr = mongoOptions.servers[0];
+    options.host = srvr.host;
+    options.port = parseInt(srvr.port);
   }
 
   // Mongdb does not support a collection name on the second segment. So we continue this workaround.
@@ -286,32 +291,6 @@ function parseUrl(path) {
       options.collection = pathname[2]
     }
   }
-
-
-/*
-  Note: We have mongoOptions.mongos_options available as well...
-
-  object.dbName
-  object.server_options = serverOptions;
-  object.db_options = dbOptions;
-  object.rs_options = replSetServersOptions;
-  object.mongos_options = {};
-  object.servers
-
-  if (Array.isArray(opts.db.servers)) {
-    var serverArray = []
-
-    opts.db.servers.forEach(function (server) {
-      var serverOptions = server.options || {}
-      serverOptions.ssl = serverOptions.ssl || opts.ssl || defaultOptions.ssl
-      var newServer = new mongo.Server(server.host, server.port, serverOptions)
-      serverArray.push(newServer)
-    })
-
-    return new mongo.Db(opts.db.name, new mongo.ReplSetServers(serverArray), opts.db.replicaSetOptions || {'w': 1})
-
-
-*/
 
   return options;
 }
@@ -326,30 +305,32 @@ function parseUrl(path) {
  */
 function setupDb(opts) {
   if (opts.mongooseConnection) {
-    var _opts = dbFromMongooseConnection(opts.mongooseConnection)
-    opts.db = _opts.db
-    opts.host = _opts.host
-    opts.port = _opts.port
-    opts.username = _opts.username
-    opts.password = _opts.password
+    var _opts = dbFromMongooseConnection(opts.mongooseConnection);
+    opts.db = _opts.db;
+    opts.host = _opts.host;
+    opts.port = _opts.port;
+    opts.username = _opts.username;
+    opts.password = _opts.password;
   }
 
-  if (!opts.db) throw new Error('Required MongoStore option `db` missing')
+  if (!opts.db) {
+    throw new Error('Required MongoStore option `db` missing');
+  }
+
   if (typeof opts.db == 'object' && opts.db.databaseName) {
     return opts.db; // Assume it's an instantiated DB Object
   }
 
   if (Array.isArray(opts.db.servers)) {
-    var serverArray = []
-
+    var serverArray = [];
     opts.db.servers.forEach(function (server) {
-      var serverOptions = server.options || {}
-      serverOptions.ssl = serverOptions.ssl || opts.ssl || defaultOptions.ssl
-      var newServer = new mongo.Server(server.host, server.port, serverOptions)
-      serverArray.push(newServer)
+      var serverOptions = server.options || {};
+      serverOptions.ssl = serverOptions.ssl || opts.ssl || defaultOptions.ssl;
+      var newServer = new mongo.Server(server.host, server.port, serverOptions);
+      serverArray.push(newServer);
     })
 
-    return new mongo.Db(opts.db.name, new mongo.ReplSetServers(serverArray), opts.db.replicaSetOptions || {'w': 1})
+    return new mongo.Db(opts.db.name, new mongo.ReplSetServers(serverArray), opts.db.replicaSetOptions || {'w': 1});
   }
 
   if (typeof opts.db != 'string') {
@@ -364,7 +345,7 @@ function setupDb(opts) {
         auto_reconnect: opts.autoReconnect || defaultOptions.autoReconnect,
         ssl: opts.ssl || defaultOptions.ssl
       }),
-    { w: opts.w || defaultOptions.w })
+    { w: opts.w || defaultOptions.w });
 }
 
 

--- a/lib/connect-mongostore.js
+++ b/lib/connect-mongostore.js
@@ -1,9 +1,9 @@
-'use strict'
+"use strict"
 
-var mongo = require('mongodb')
-  , url = require('url')
-  , util = require('util')
-  , _ = require('lodash')
+var mongo = require('mongodb'),
+    url = require('url'),
+    util = require('util'),
+    _ = require('lodash');
 
 
 /**
@@ -18,7 +18,7 @@ var defaultOptions = {
   'autoReconnect': false,
   'ssl': false,
   'w': 1
-}
+};
 
 
 
@@ -29,23 +29,28 @@ function getStore(Store) {
    * @param {Object} options
    */
   function MongoStore (options, callback) {
+    var self = this;
+
     Store.call(this, this.options)
 
-    if (typeof options == 'string') {
-      this.options = parseUrl(options)
-    } else {
-      this.options = _.clone(options || {})
-      this.options.expireAfter = this.options.expireAfter || defaultOptions.expireAfter
+    if (typeof options === 'string') {
+      this.options = parseUrl(options);
+    }
+    else {
+      this.options = _.clone(options || {});
+      this.options.expireAfter = this.options.expireAfter || defaultOptions.expireAfter;
     }
 
     if (!this.options.hasOwnProperty('stringify')) {
-      this.options.stringify = defaultOptions.stringify
+      this.options.stringify = defaultOptions.stringify;
     }
 
-    this.collectionName = this.options.collection || defaultOptions.collection
-    this.db = setupDb(this.options)
+    this.collectionName = this.options.collection || defaultOptions.collection;
 
-    callback && this.getDatabase(callback);
+    mongo.MongoClient.connect(options, function(err, database) {
+        self.db = database;
+        callback && self.getCollection(callback);
+    });
   }
 
 
@@ -53,43 +58,24 @@ function getStore(Store) {
   /**
    * Inherit from `Store`.
    */
-  util.inherits(MongoStore, Store)
+  util.inherits(MongoStore, Store);
 
 
 
   MongoStore.prototype.serialize = function (obj) {
     if (this.options.stringify) {
-      return JSON.stringify(obj)
+      return JSON.stringify(obj);
     }
-    return obj
+    return obj;
   }
 
 
   MongoStore.prototype.deserialize = function (str) {
     if (this.options.stringify) {
-      return JSON.parse(str)
+      return JSON.parse(str);
     }
-    return str
+    return str;
   }
-
-
-  MongoStore.prototype.getDatabase = function (cb) {
-    var self = this
-
-    self.db.open(function (err, db) {
-      if (err) throw new Error('Error connecting to database:\n' + err.message + '\n' + err.stack + '\n')
-
-      if (self.options.username && self.options.password) {
-        db.authenticate(self.options.username, self.options.password, {authSource: self.options.authSource || null}, function () {
-          self.getCollection(cb)
-        })
-      } else {
-        self.getCollection(cb)
-      }
-    })
-  }
-
-
 
   /**
    * Returns a MongoDB collection.
@@ -97,23 +83,25 @@ function getStore(Store) {
    * @param cb
    */
   MongoStore.prototype.getCollection = function (cb) {
-    var self = this
+    var self = this;
 
     if (self.collection) {
-      cb && cb(self.collection)
-      return
+      cb && cb(self.collection);
+      return;
     }
 
-    if (!self.db.openCalled) return self.getDatabase(cb)
-
     self.db.collection(self.collectionName, function (err, collection) {
-      if (err) throw new Error('Error getting collection: ' + self.collectionName + ' <' + err + '>')
+      if (err) {
+        throw new Error('Error getting collection: ' + self.collectionName + ' <' + err + '>')
+      }
 
-      self.collection = collection
+      self.collection = collection;
 
       self.collection.ensureIndex({'expires': 1}, {'expireAfterSeconds': 0}, function (err, result) {
-        if (err) throw new Error('Error setting TTL index on collection : ' + self.collectionName + ' <' + err + '>')
-        cb && cb(self.collection)
+        if (err) {
+            throw new Error('Error setting TTL index on collection : ' + self.collectionName + ' <' + err + '>')
+        }
+        cb && cb(self.collection);
       })
     })
   }
@@ -295,7 +283,8 @@ function parseUrl(path) {
  *
  * @param opts
  * @returns {*}
- */
+    MongoDb*/
+
 function setupDb(opts) {
   if (opts.mongooseConnection) {
     var _opts = dbFromMongooseConnection(opts.mongooseConnection)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "connect-mongostore",
-  "version": "0.1.4",
+  "name": "connect-mongostore-2",
+  "version": "0.2.0",
   "description": "MongoDB session store for Connect",
   "keywords": [
     "connect",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "connect-mongostore-2",
-  "version": "0.2.1",
+  "name": "connect-mongostore",
+  "version": "0.5.0",
   "description": "MongoDB session store for Connect",
   "keywords": [
     "connect",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-mongostore-2",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "MongoDB session store for Connect",
   "keywords": [
     "connect",


### PR DESCRIPTION
This function now gets a well parsed url based on the parse function that MongoDb uses. Then this function maps the parsed data into an options structure that matches what this module was expecting.

We've added an early version of the changes to this module to our local repository under a different name to keep moving forward, but I wanted to see if I could contribute back to this module. If this pull request is accepted we'll change over to using the published version here. Let me know if you have any questions or concerns. Thanks!
