### PR TITLE
Use replica set options

### DIFF
--- a/lib/connect-mongostore.js
+++ b/lib/connect-mongostore.js
@@ -318,8 +318,8 @@ function setupDb(opts) {
       var newServer = new mongo.Server(server.host, server.port, serverOptions)
       serverArray.push(newServer)
     })
-
-    return new mongo.Db(opts.db.name, new mongo.ReplSetServers(serverArray), opts.db.replicaSetOptions || {'w': 1})
+    var options = opts.db.replicaSetOptions || {'w': 1};
+    return new mongo.Db(opts.db.name, new mongo.ReplSet(serverArray, options))
   }
 
   if (typeof opts.db != 'string') throw new Error('`db` option must be a string, array or a database instance.')


### PR DESCRIPTION
According to the docs:

http://mongodb.github.io/node-mongodb-native/api-generated/db.html
http://mongodb.github.io/node-mongodb-native/api-generated/replset.html

The replica set options should be used as a parameter for ReplSet, not Db (which uses options, not replica set options). Also it looks like ReplSet is now being used instead of ReplSetServers:

https://github.com/mongodb/node-mongodb-native/pull/937
