### PR TITLE
bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-mongostore",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "MongoDB session store for Connect",
   "keywords": [
     "connect",
@@ -18,7 +18,7 @@
     "url": "https://github.com/diversario/connect-mongostore/issues"
   },
   "dependencies": {
-    "mongodb": "~1.4",
+    "mongodb": "~2",
     "lodash": "~2.4"
   },
   "directories": {


### PR DESCRIPTION
to avoid the annoying "js-bson: Failed to load c++ bson extension, using pure JS version" error at least for iojs 2.3
